### PR TITLE
closes #24 Add option to clean up all job and pods after completed

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/h3poteto/kube-job/job"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,7 @@ type runJob struct {
 	templateFile string
 	container    string
 	timeout      int
-	cleanup      bool
+	cleanup      string
 }
 
 func runJobCmd() *cobra.Command {
@@ -29,7 +30,7 @@ func runJobCmd() *cobra.Command {
 	flags.StringVar(&r.args, "args", "", "Command which you want to run")
 	flags.StringVar(&r.container, "container", "", "Container name which you want watch the log")
 	flags.IntVarP(&r.timeout, "timeout", "t", 0, "Timeout seconds")
-	flags.BoolVar(&r.cleanup, "cleanup", true, "Cleanup completed job after run the job if the job is succeeded")
+	flags.StringVar(&r.cleanup, "cleanup", "succeeded", "Cleanup completed job after run the job. You can specify 'all', 'succeeded' or 'failed'.")
 
 	return cmd
 }
@@ -40,17 +41,19 @@ func (r *runJob) run(cmd *cobra.Command, args []string) {
 	if !verbose {
 		log.SetLevel(log.WarnLevel)
 	}
+	if r.cleanup != job.All.String() && r.cleanup != job.Succeeded.String() && r.cleanup != job.Failed.String() {
+		err := errors.New("Please set 'all', 'succeeded' or 'failed' as --cleanup.")
+		log.Fatal(err)
+	}
+
 	log.Infof("Using config file: %s", config)
 	j, err := job.NewJob(config, r.templateFile, r.args, r.container, (time.Duration(r.timeout) * time.Second))
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := j.Run(); err != nil {
+
+	if err := j.RunAndCleanup(r.cleanup); err != nil {
 		log.Fatal(err)
 	}
-	if r.cleanup {
-		if err := j.Cleanup(); err != nil {
-			log.Fatal(err)
-		}
-	}
+
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,7 +42,7 @@ func (r *runJob) run(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.WarnLevel)
 	}
 	if r.cleanup != job.All.String() && r.cleanup != job.Succeeded.String() && r.cleanup != job.Failed.String() {
-		err := errors.New("Please set 'all', 'succeeded' or 'failed' as --cleanup.")
+		err := errors.New("please set 'all', 'succeeded' or 'failed' as --cleanup")
 		log.Fatal(err)
 	}
 

--- a/job/runner.go
+++ b/job/runner.go
@@ -53,11 +53,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// CleanupType for enum.
 type CleanupType int
 
 const (
+	// All is a clean up type. Remove the job and pods whether the job is succeeded or failed.
 	All CleanupType = iota
+	// Succeeded is a clean up type. Remove the job and pods when the job is succeeded.
 	Succeeded
+	// Failed is a cleanup type. Remove the job and pods when the job is failed.
 	Failed
 )
 
@@ -92,7 +96,7 @@ func (j *Job) Run() error {
 	return err
 }
 
-// Run a command and clean up jobs and pods.
+// RunAndCleanup executes a command and clean up the job and pods.
 func (j *Job) RunAndCleanup(cleanupType string) error {
 	err := j.Run()
 	if cleanupType == All.String() || (cleanupType == Succeeded.String() && err == nil) || (cleanupType == Failed.String() && err != nil) {

--- a/job/watcher_test.go
+++ b/job/watcher_test.go
@@ -13,7 +13,7 @@ func TestParseLabels(t *testing.T) {
 	}
 	parsed := parseLabels(labels)
 	if parsed != "app=job,version=1" {
-		t.Error("Parsed label does not match")
+		t.Errorf("Parsed label does not match: %s", parsed)
 	}
 }
 


### PR DESCRIPTION
I change `cleanup` option. For example:

```
Usage:
  kube-job run [flags]

Flags:
      --args string            Command which you want to run
      --cleanup string         Cleanup completed job after run the job. You can specify 'all', 'succeeded' or 'failed'. (default "succeeded")
      --container string       Container name which you want watch the log
  -h, --help                   help for run
  -f, --template-file string   Job template file
  -t, --timeout int            Timeout seconds

Global Flags:
      --config KUBECONFIG   Kubernetes config file path (If you don't set it, use environment variables KUBECONFIG)
  -v, --verbose             Enable verbose mode
```