### PR TITLE
Don't override container args if args flag is not passed

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -147,7 +147,9 @@ func (j *Job) RunJob() (*v1.Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	currentJob.Spec.Template.Spec.Containers[index].Args = j.Args
+	if len(j.Args) > 0 {
+		currentJob.Spec.Template.Spec.Containers[index].Args = j.Args
+	}
 
 	resultJob, err := j.client.BatchV1().Jobs(j.CurrentJob.Namespace).Create(currentJob)
 	if err != nil {


### PR DESCRIPTION
Hi @h3poteto,
Thanks for your great work.

My job template has already the good command args and I don't need to change them.
But they are erased with the command even if I don't passed `--args` flag.