### PR TITLE
Use InClusterConfig when no config is supplied

### DIFF
--- a/pkg/job/config.go
+++ b/pkg/job/config.go
@@ -1,11 +1,24 @@
 package job
 
 import (
+	"os"
+
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 func newClient(configFile string) (*kubernetes.Clientset, error) {
+	_, err := os.Stat(configFile)
+	if err != nil {
+		kubeConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		return kubernetes.NewForConfig(kubeConfig)
+	}
+
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", configFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi @h3poteto,
Thanks for your great work.

### What this PR does / why we need it:

This PR support running kube-job inside the Kubernetes cluster.

I want to run kube-jobs inside the Kubernetes cluster (e.g. Pods).
But, We need to share the Kubernetes config file to the cluster.

client-go provides `rest.InClusterConfig()` to access the Kubernetes API inside the cluster.
https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration

So, if Kubernetes config file is not supplied, I want to try to authenticate using `rest.InClusterConfig()`.