### PR TITLE
better explanation for --template-file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ fuga
 You can specify an URL as a template file, like this:
 
 ```
-$ ./kube-job run --template-file=https://github.com/h3poteto/kube-job/example/job.yaml --args="echo fuga" --container="alpine"
+$ ./kube-job run --template-file=https://raw.githubusercontent.com/h3poteto/kube-job/master/example/job.yaml --args="echo fuga" --container="alpine"
 ```
 
 If your template file is located in private repository, please export personal access token of GitHub. And please use an API URL endpoint.


### PR DESCRIPTION
Hi :hand: 
At first glance, it seems that `--template-file` option works even with the URL of GitHub API or GitHub HTML page, but it does not work properly unless the URL returns raw YAML, when `GITHUB_TOKEN` is not set.
ref: https://github.com/h3poteto/kube-job/blob/master/pkg/job/job.go#L101-L103

Thanks.