### PR TITLE
bugfix: Job could be removed before starting correctly

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -215,7 +215,7 @@ retry:
 		if err != nil {
 			return err
 		}
-		if running.Status.Active == 0 {
+		if running.Status.Active == 0 && (running.Status.Succeeded == 1 || running.Status.Failed == 1) {
 			return checkJobConditions(running.Status.Conditions)
 		}
 		if ignoreSidecar {


### PR DESCRIPTION
Hi @h3poteto :hand: 

In my environment, it takes about 20 seconds to get job status from k8s API after creating job resources.
Just after creating a job, k8s returns blank status as following:
```
$ kubectl get job -o json
{
...
    "status": {}
}

# after 20 sec, it returns like
{
...
    "status": {
        "active": 1,
        "startTime": "2021-05-20T15:10:42Z"
    }
}
```

During this state, [this condition](https://github.com/h3poteto/kube-job/blob/master/pkg/job/job.go#L218) is True. As the result of that, the Job is removed before starting.

For example, following job should be lived at least 30 secounds, though it removed just after 3 seconds after first status check.
```
$ kube-job run --config="$HOME/.kube/config" --template-file=https://raw.githubusercontent.com/h3poteto/kube-job/master/example/job.yaml --args="sleep 30" --container="alpine" --verbose=true
INFO[0000] Using config file: /path/to/.kube/config 
INFO[0000] Received args:                               
INFO[0000] sleep                                        
INFO[0000] 30                                           
INFO[0000] Starting job: example-job-c02549e48f3da3a54120f6fd39c3d9ca 
INFO[0000] Waiting for running job...                   
INFO[0003] Job is succeeded  # <= SEE HERE
INFO[0013] Removing the job: example-job-c02549e48f3da3a54120f6fd39c3d9ca 
INFO[0013] Remove related pods which labels is: job-name=example-job-c02549e48f3da3a54120f6fd39c3d9ca 
```

Therefore, I fixed it using a status of Succeeded or Failed. I've tested that this fix prevent removing job before starting and worked correctly.

Thanks,
