### PR TITLE
Fix: random generated label length

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -129,7 +130,9 @@ func downloadFile(rawurl string) (string, error) {
 }
 
 func generateRandomName(name string) string {
-	return fmt.Sprintf("%s-%s", name, secureRandomStr(16))
+	// label must be no more than 63 characters long
+	lengthToGenerate := math.Min(float64(62 - len(name)), float64(32))
+	return fmt.Sprintf("%s-%s", name, secureRandomStr(int(lengthToGenerate) / 2))
 }
 
 // secureRandomStr is generate random string.

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -81,6 +82,18 @@ func (m mockedKubernetes) BatchV1() batchv1.BatchV1Interface {
 
 func (m mockedKubernetes) CoreV1() corev1.CoreV1Interface {
 	return m.mockedCore
+}
+
+func TestGenerateRandomName(t *testing.T) {
+	name := generateRandomName("foo")
+	if len(name) != 3 + 1 + 32 {
+		t.Error("name length is not correct")
+	}
+
+	name = generateRandomName(strings.Repeat("bar", 20))
+	if len(name) != 63 {
+		t.Error("name length is not correct")
+	}
 }
 
 func TestRunJob(t *testing.T) {

--- a/pkg/job/runner.go
+++ b/pkg/job/runner.go
@@ -76,6 +76,7 @@ func (j *Job) Run(ignoreSidecar bool) error {
 	}
 	running, err := j.RunJob()
 	if err != nil {
+		log.Error(err)
 		return err
 	}
 	log.Infof("Starting job: %s", running.Name)


### PR DESCRIPTION
When long label name is used for job in manifest file, label name generated by kube-job violate the length limit.

error occurs like below:
```
Job.batch "this-is-long-label-named-job-hello-hello-hello-451746b71378ea96346fa9924b18ecb5" is invalid: spec.template.labels: Invalid value: "this-is-long-label-named-job-hello-hello-hello-451746b71378ea96346fa9924b18ecb5": must be no more than 63 characters
```