### PR TITLE
add override docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `kube-job` is a command line tool to run one off job on Kubernetes. The feature is
 
-- Override args argument in a kubernetes job template, and run the job.
+- Override args argument and docker image in a kubernetes job template, and run the job.
 - Wait for completion of the job execution
 - Get logs from kubernetes pods and output in stream
 
@@ -90,7 +90,7 @@ spec:
 
 ```
 
-`metadata.name` and `spec.template.spec.containers[0].args` are overrided when you use `kube-job`.
+`metadata.name` and `spec.template.spec.containers[0].args`, `spec.template.spec.containers[0].image` are overrided when you use `kube-job`.
 
 #### Why override name?
 Kubernetes creates a job based on the job template yaml file, so if you use `kube-job` more than once at the same time, it is failed.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,6 +12,7 @@ import (
 type runJob struct {
 	args          string
 	templateFile  string
+	image         string
 	container     string
 	timeout       int
 	cleanup       string
@@ -29,6 +30,7 @@ func runJobCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&r.templateFile, "template-file", "f", "", "Job template file")
 	flags.StringVar(&r.args, "args", "", "Command which you want to run")
+	flags.StringVar(&r.image, "image", "", "Image which you want to run")
 	flags.StringVar(&r.container, "container", "", "Container name which you want watch the log")
 	flags.IntVarP(&r.timeout, "timeout", "t", 0, "Timeout seconds")
 	flags.StringVar(&r.cleanup, "cleanup", "all", "Cleanup completed job after run the job. You can specify 'all', 'succeeded' or 'failed'.")
@@ -49,7 +51,7 @@ func (r *runJob) run(cmd *cobra.Command, args []string) {
 	}
 
 	log.Infof("Using config file: %s", config)
-	j, err := job.NewJob(config, r.templateFile, r.args, r.container, (time.Duration(r.timeout) * time.Second))
+	j, err := job.NewJob(config, r.templateFile, r.args, r.image, r.container, (time.Duration(r.timeout) * time.Second))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -3,9 +3,9 @@ package job
 import (
 	"context"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -86,7 +86,7 @@ func (m mockedKubernetes) CoreV1() corev1.CoreV1Interface {
 
 func TestGenerateRandomName(t *testing.T) {
 	name := generateRandomName("foo")
-	if len(name) != 3 + 1 + 32 {
+	if len(name) != 3+1+32 {
 		t.Error("name length is not correct")
 	}
 
@@ -112,7 +112,7 @@ func TestRunJob(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
-		Image: "alpine:latest",
+		Image:      "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -179,7 +179,7 @@ func TestWaitJobCompleteWithWaitAll(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
-		Image: "alpine:latest",
+		Image:      "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -271,7 +271,7 @@ func TestWaitJobCompleteForContainer(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
-		Image: "alpine:latest",
+		Image:      "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -519,7 +519,7 @@ func TestRemovePods(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
-		Image: "alpine:latest",
+		Image:      "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -112,6 +112,7 @@ func TestRunJob(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
+		Image: "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -178,6 +179,7 @@ func TestWaitJobCompleteWithWaitAll(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
+		Image: "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -269,6 +271,7 @@ func TestWaitJobCompleteForContainer(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
+		Image: "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -516,6 +519,7 @@ func TestRemovePods(t *testing.T) {
 	job := &Job{
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
+		Image: "alpine:latest",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{


### PR DESCRIPTION
I want docker image tag to be mutable. Because, there are cases where you want to build a docker image with GitHub Actions and use it . For that reason, I want to give kube-job the ability to override the docker image