### PR TITLE
Add ability to override namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `kube-job` is a command line tool to run one off job on Kubernetes. The feature is
 
-- Override args argument and docker image in a kubernetes job template, and run the job.
+- Override args argument, namespace and docker image in a kubernetes job template, and run the job.
 - Wait for completion of the job execution
 - Get logs from kubernetes pods and output in stream
 
@@ -90,7 +90,7 @@ spec:
 
 ```
 
-`metadata.name` and `spec.template.spec.containers[0].args`, `spec.template.spec.containers[0].image` are overrided when you use `kube-job`.
+`metadata.name`,`metadata.namespace`, `spec.template.spec.containers[0].args` and `spec.template.spec.containers[0].image` are overrided when you use `kube-job`.
 
 #### Why override name?
 Kubernetes creates a job based on the job template yaml file, so if you use `kube-job` more than once at the same time, it is failed.
@@ -111,6 +111,8 @@ The container parameter receives which container do you want to execute the comm
 $ ./kube-job run --config=$HOME/.kube/config --template-file=./job.yaml --args="echo fuga" --container="alpine"
 fuga
 ```
+
+> You can optionally add `--namespace` to override namespace on the job template or `--image` to override the container image 
 
 ### Specify an URL as a template file
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,7 @@ type runJob struct {
 	args          string
 	templateFile  string
 	image         string
+	namespace     string
 	container     string
 	timeout       int
 	cleanup       string
@@ -31,6 +32,7 @@ func runJobCmd() *cobra.Command {
 	flags.StringVarP(&r.templateFile, "template-file", "f", "", "Job template file")
 	flags.StringVar(&r.args, "args", "", "Command which you want to run")
 	flags.StringVar(&r.image, "image", "", "Image which you want to run")
+	flags.StringVar(&r.namespace, "namespace", "", "namespace where the job will be run")
 	flags.StringVar(&r.container, "container", "", "Container name which you want watch the log")
 	flags.IntVarP(&r.timeout, "timeout", "t", 0, "Timeout seconds")
 	flags.StringVar(&r.cleanup, "cleanup", "all", "Cleanup completed job after run the job. You can specify 'all', 'succeeded' or 'failed'.")
@@ -51,7 +53,7 @@ func (r *runJob) run(cmd *cobra.Command, args []string) {
 	}
 
 	log.Infof("Using config file: %s", config)
-	j, err := job.NewJob(config, r.templateFile, r.args, r.image, r.container, (time.Duration(r.timeout) * time.Second))
+	j, err := job.NewJob(config, r.templateFile, r.args, r.image, r.namespace, r.container, (time.Duration(r.timeout) * time.Second))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -35,6 +35,8 @@ type Job struct {
 	Args []string
 	// Target docker image.
 	Image string
+	// Target namespace
+	Namespace string
 	// Target container name.
 	Container string
 	// If you set 0, timeout is ignored.
@@ -43,7 +45,7 @@ type Job struct {
 
 // NewJob returns a new Job struct, and initialize kubernetes client.
 // It read the job definition yaml file, and unmarshal to batch/v1/Job.
-func NewJob(configFile, currentFile, command, image, container string, timeout time.Duration) (*Job, error) {
+func NewJob(configFile, currentFile, command, image, namespace, container string, timeout time.Duration) (*Job, error) {
 	if len(configFile) == 0 {
 		return nil, errors.New("Config file is required")
 	}
@@ -71,7 +73,9 @@ func NewJob(configFile, currentFile, command, image, container string, timeout t
 		return nil, err
 	}
 	currentJob.SetName(generateRandomName(currentJob.Name))
-
+	if len(namespace) > 0 {
+		currentJob.SetNamespace(namespace)
+	}
 	p := shellwords.NewParser()
 	args, err := p.Parse(command)
 	log.Info("Received args:")
@@ -87,6 +91,7 @@ func NewJob(configFile, currentFile, command, image, container string, timeout t
 		&currentJob,
 		args,
 		image,
+		namespace,
 		container,
 		timeout,
 	}, nil

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -113,6 +113,7 @@ func TestRunJob(t *testing.T) {
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
 		Image:      "alpine:latest",
+		Namespace:  "default",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -180,6 +181,7 @@ func TestWaitJobCompleteWithWaitAll(t *testing.T) {
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
 		Image:      "alpine:latest",
+		Namespace:  "default",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -272,6 +274,7 @@ func TestWaitJobCompleteForContainer(t *testing.T) {
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
 		Image:      "alpine:latest",
+		Namespace:  "default",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{
@@ -520,6 +523,7 @@ func TestRemovePods(t *testing.T) {
 		CurrentJob: currentJob,
 		Args:       []string{"hoge", "fuga"},
 		Image:      "alpine:latest",
+		Namespace:  "default",
 		Container:  "alpine",
 		Timeout:    10 * time.Minute,
 		client: mockedKubernetes{


### PR DESCRIPTION
For most of the usecases, you may need to run jobs on multiple namespaces/ different from the default namespace within the template. 
Added the ability to optionally override namespace .