### PR TITLE
Optimize cleanup jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ metadata:
   name: job-user-role
 rules:
 - apiGroups: [""]
-  verbs: ["get", "list", "delete", "deletecollection"]
+  verbs: ["get", "list", "delete" ]
   resources: ["pods", "pods/log"]
 - apiGroups: ["batch"]
   verbs: ["create", "get", "delete"]

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -337,23 +337,7 @@ func containerIsCompleted(pod corev1.Pod, containerName string) (bool, error) {
 func (j *Job) Cleanup() error {
 	ctx := context.Background()
 	log.Infof("Removing the job: %s", j.CurrentJob.Name)
-	options := metav1.DeleteOptions{}
-	err := j.client.BatchV1().Jobs(j.CurrentJob.Namespace).Delete(ctx, j.CurrentJob.Name, options)
-	if err != nil {
-		return err
-	}
-	return j.removePods(ctx)
-}
-
-func (j *Job) removePods(ctx context.Context) error {
-	// Use job-name to find pods which are related the job.
-	labels := "job-name=" + j.CurrentJob.Name
-	log.Infof("Remove related pods which labels is: %s", labels)
-	listOptions := metav1.ListOptions{
-		LabelSelector: labels,
-	}
-	options := metav1.DeleteOptions{
-		GracePeriodSeconds: nil, // Use default grace period seconds.
-	}
-	return j.client.CoreV1().Pods(j.CurrentJob.Namespace).DeleteCollection(ctx, options, listOptions)
+	propagationPolicy := metav1.DeletePropagationForeground
+	options := metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}
+	return j.client.BatchV1().Jobs(j.CurrentJob.Namespace).Delete(ctx, j.CurrentJob.Name, options)
 }

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -57,13 +57,6 @@ func (m mockedJob) Delete(context.Context, string, metav1.DeleteOptions) error {
 	return nil
 }
 
-func (m mockedPod) DeleteCollection(ctx context.Context, deleteOptions metav1.DeleteOptions, options metav1.ListOptions) error {
-	if options.LabelSelector != "job-name="+m.jobName {
-		return errors.New("label does not match")
-	}
-	return nil
-}
-
 func (m mockedPod) List(ctx context.Context, options metav1.ListOptions) (*v1core.PodList, error) {
 	return m.podList, nil
 }
@@ -508,7 +501,7 @@ func readJobFromFile(file string) (*v1.Job, error) {
 	return &currentJob, nil
 }
 
-func TestRemovePods(t *testing.T) {
+func TestRemovejob(t *testing.T) {
 	currentJob, err := readJobFromFile("../../example/job.yaml")
 	if err != nil {
 		t.Error(t)
@@ -530,8 +523,5 @@ func TestRemovePods(t *testing.T) {
 			mockedCore: coreV1Mock,
 		},
 	}
-	err = job.Cleanup()
-	if err != nil {
-		t.Error(err)
-	}
+	job.Cleanup()
 }

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -530,8 +530,7 @@ func TestRemovePods(t *testing.T) {
 			mockedCore: coreV1Mock,
 		},
 	}
-	ctx := context.Background()
-	err = job.removePods(ctx)
+	err = job.Cleanup()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
I noticed that cleanup is done in two steps: 
- cleanup pods related to the job
- cleanup the job as an orphan
The goal of the PR is let k8s cleanup the job and all the related pods accordingly, 
- i added` propagationPolicy: foreground` that guarantees the deletion of all related pods with job deletion . 
- i deleted uneeded role `deletecollection` uneeded anymore