### PR TITLE
Fix goroutine leak in Watcher while a job is running

### DIFF
--- a/pkg/job/watcher.go
+++ b/pkg/job/watcher.go
@@ -50,11 +50,13 @@ retry:
 
 		incrementalPodList := diffPods(currentPodList, newPodList)
 
-		go func() {
-			if err := w.WatchPods(ctx, incrementalPodList); err != nil {
-				errCh <- err
-			}
-		}()
+		if len(incrementalPodList) > 0 {
+			go func() {
+				if err := w.WatchPods(ctx, incrementalPodList); err != nil {
+					errCh <- err
+				}
+			}()
+		}
 
 		select {
 		case err := <-errCh:
@@ -68,6 +70,9 @@ retry:
 
 // WatchPods gets wait to start pod and tail the logs.
 func (w *Watcher) WatchPods(ctx context.Context, pods []corev1.Pod) error {
+	if len(pods) == 0 {
+		return nil
+	}
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(pods))
 

--- a/pkg/job/watcher_test.go
+++ b/pkg/job/watcher_test.go
@@ -114,7 +114,9 @@ func TestWatchDoesNotLeakGoroutinesWhenNoNewPods(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go watcher.Watch(job, ctx)
+	go func() {
+		_ = watcher.Watch(job, ctx)
+	}()
 
 	// Wait for the watch loop to reach steady state, then sample the goroutine count twice.
 	time.Sleep(2 * time.Second)

--- a/pkg/job/watcher_test.go
+++ b/pkg/job/watcher_test.go
@@ -2,10 +2,14 @@ package job
 
 import (
 	"context"
+	"runtime"
 	"testing"
+	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func (m mockedPod) Get(context.Context, string, metav1.GetOptions) (*v1.Pod, error) {
@@ -98,5 +102,28 @@ func TestWaitToStartPod(t *testing.T) {
 	}
 	if pod.Name != runningPod.Name {
 		t.Error("pod does not match")
+	}
+}
+
+func TestWatchDoesNotLeakGoroutinesWhenNoNewPods(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	watcher := NewWatcher(client, "alpine")
+	job := &batchv1.Job{}
+	job.Namespace = "default"
+	job.Spec.Template.Labels = map[string]string{"app": "leak-test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go watcher.Watch(job, ctx)
+
+	// Wait for the watch loop to reach steady state, then sample the goroutine count twice.
+	time.Sleep(2 * time.Second)
+	before := runtime.NumGoroutine()
+	time.Sleep(4 * time.Second)
+	after := runtime.NumGoroutine()
+
+	// With the leak, ~4 goroutines accumulate over 4 seconds; allow up to 2 for scheduler/GC jitter.
+	if growth := after - before; growth > 2 {
+		t.Errorf("goroutines leaked while watching a job with no new pods: %d -> %d (+%d)", before, after, growth)
 	}
 }


### PR DESCRIPTION
Fixes #280

`Watch()` spawns a `WatchPods` goroutine every second, and when the
incremental pod list is empty (the common case once the job's pod has
started) `WatchPods` blocks forever receiving from an unbuffered channel
with no senders — leaking one goroutine per second for the lifetime of
the process (~17MB RSS/hour in our measurements; details in #280).

This PR skips spawning the goroutine when the pod diff is empty, and makes
`WatchPods` return immediately for an empty pod list as a defensive measure.
Also adds a regression test using the fake clientset: without the fix,
`runtime.NumGoroutine()` grows by ~1/second during `Watch()`; with the fix
it stays flat.
